### PR TITLE
#171210876 Integrate travis badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# portfolio-backend
+[![Build Status](https://travis-ci.com/Diama1/portfolio-backend.svg?token=BxusRzdNr5xPuq5aRKmj&branch=develop)](https://travis-ci.com/Diama1/portfolio-backend)
+
+# My Portfolio


### PR DESCRIPTION
# Description

This is to enable the user to see the travis badges on the readme file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
N/A

# Pivotal tracker ref
`#171210876`
# Screenshots
N/A
